### PR TITLE
Fix deprecated openai model to use gpt-4o

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -124,7 +124,7 @@ async def chat() -> Chain:
         await cl.Message(content=f"Error: {e}").send()
 
     llm = ChatOpenAI(
-        model='gpt-3.5-turbo-16k-0613',
+        model='gpt-4o',
         temperature=0,
         streaming=True
     )


### PR DESCRIPTION
Corrects deprecated model that can no longer be used with openai to the newer one that is available for use.